### PR TITLE
Fix a broken call to fs.copyFileSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,7 @@ class ServerlessPlugin {
       const func = this.serverless.service.functions[k]
       if (func.embedded) {
         func.embedded.files.forEach((file) => {
-          fs.copyFileSync(`${file}`, `${file}.org`, (e) => {
-            console.log(e)
-          })
+          fs.copyFileSync(`${file}`, `${file}.org`)
           let result = fs.readFileSync(file, 'utf8')
           Object.keys(func.embedded.variables).forEach((k2) => {
             const val = func.embedded.variables[k2]


### PR DESCRIPTION
When using this plugin with the latest versions of Node and Serverless a TypeError is emitted because fs.copyFileSync is expecting a number and is instead receiving an anonymous function.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "mode" argument must be integer. Received type function ([Function (anonymous)])
      at Object.copyFileSync (fs.js:2057:10)
      at /Users/xxx/yyy/zzz/node_modules/serverless-plugin-embedded-env-in-code/index.js:24:14
      at Array.forEach (<anonymous>)
      at /Users/xxx/yyy/zzz/node_modules/serverless-plugin-embedded-env-in-code/index.js:23:29
      at Array.forEach (<anonymous>)
```